### PR TITLE
Update run-script.sh

### DIFF
--- a/run-script.sh
+++ b/run-script.sh
@@ -4,4 +4,4 @@ set -o pipefail
 
 echo Using KtLint version: "$(ktlint --version)"
 
-ktlint --relative
+ktlint --relative "$@"


### PR DESCRIPTION
Use the special "$@" notation to pass any command-line arguments to the ktlint command. example of use providing a custom ruleset:
```
test-linter:
      runs-on: ubuntu-latest
      steps:
        - uses: actions/checkout@v3
        - name: ktlint
          uses: lucasnlm/ktlint-action@master
          with:
            args: --ruleset=/path/to/custom-ruleset.jar
```